### PR TITLE
Add login page option for SSO redirects

### DIFF
--- a/src/IConfigOptions.ts
+++ b/src/IConfigOptions.ts
@@ -219,4 +219,5 @@ export interface IConfigOptions {
 export interface ISsoRedirectOptions {
     immediate?: boolean;
     on_welcome_page?: boolean;
+    on_login_page?: boolean;
 }


### PR DESCRIPTION
This adds the option to redirect to SSO from the login page. This may help when SSO should be the only login option, while still allowing guests to view public rooms.

Coincides with the following change: https://github.com/element-hq/element-web/pull/27576

Signed-off-by: Bart van der Braak [bartvdbraak@gmail.com](mailto:bartvdbraak@gmail.com)